### PR TITLE
fix: swift version 5

### DIFF
--- a/Socket.IO-Client-Swift.podspec
+++ b/Socket.IO-Client-Swift.podspec
@@ -22,9 +22,9 @@ Pod::Spec.new do |s|
     :submodules => true
   }
 
-  s.swift_version = "4.2"
+  s.swift_version = "5"
   s.pod_target_xcconfig = {
-      'SWIFT_VERSION' => '4.2'
+      'SWIFT_VERSION' => '5.0'
   }
   s.source_files  = "Source/SocketIO/**/*.swift", "Source/SocketIO/*.swift"
   s.dependency "Starscream", "~> 4.0"


### PR DESCRIPTION
I'm guessing this was introduced when a merge was resolved.

https://github.com/triniwiz/socket.io-client-swift/commit/a0c6573ae6990ad7f590d254d15937a788a93600

We are getting this error:

```
Pre-downloading: `Socket.IO-Client-Swift` from `https://github.com/triniwiz/socket.io-client-swift.git`
[!] CocoaPods could not find compatible versions for pod "Socket.IO-Client-Swift":
  In Podfile:
    Socket.IO-Client-Swift (from `https://github.com/triniwiz/socket.io-client-swift.git`)

Specs satisfying the `Socket.IO-Client-Swift (from `https://github.com/triniwiz/socket.io-client-swift.git`)` dependency were found, but they required a higher minimum deployment target.
'pod install' command failed.
```